### PR TITLE
Fix default language path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ How can you provide a translation for **CloudPanel**?
 
 1. Fork this repository.
 
-2. Copy **v2/en_en** to your locale e.g. **v2/es_es**.
+2. Copy **v2/en_us** to your locale e.g. **v2/es_es**.
 
 3. Translate the files **messages.xlf** and **validators.xlf** and **file-manager.js**.
 


### PR DESCRIPTION
In the CloudPanel translation rules there was a reference to the **en_en** folder which does not exist while the correct name is **en_us**